### PR TITLE
Silverstripe 6 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "ryanpotter/silverstripe-color-field",
+  "name": "prij/silverstripe-color-field",
   "description": "Silverstripe Color Field",
   "type": "silverstripe-vendormodule",
   "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }
   ],
   "require": {
-    "silverstripe/framework": "^4.0 || ^5.0"
+    "silverstripe/framework": "^4.0 || ^5.0 || ^6"
   },
   "support": {
     "issues": "https://github.com/Rhym/silverstripe-color-field/issues"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "prij/silverstripe-color-field",
+  "name": "ryanpotter/silverstripe-color-field",
   "description": "Silverstripe Color Field",
   "type": "silverstripe-vendormodule",
   "keywords": [

--- a/src/Forms/ColorField.php
+++ b/src/Forms/ColorField.php
@@ -2,6 +2,7 @@
 
 namespace RyanPotter\SilverStripeColorField\Forms;
 
+use SilverStripe\Core\Validation\ValidationResult;
 use SilverStripe\Forms\TextField;
 use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\View\Requirements;
@@ -93,9 +94,9 @@ class ColorField extends TextField
    * @param \SilverStripe\Forms\Validator $validator
    * @return bool
    */
-  function validate($validator): bool
+  public function validate(): ValidationResult
   {
-    return true;
+    return ValidationResult::create();
   }
 
   /**


### PR DESCRIPTION
Adds SilverStripe 6 compatibility:
- Updating the `validate()` method in `ColorField` to match the required return type (`ValidationResult`) in SilverStripe 6 / PHP 8+
- Updating `composer.json` to allow installation on `"silverstripe/framework": ^6`